### PR TITLE
corrected repo URL

### DIFF
--- a/at24c32n.py
+++ b/at24c32n.py
@@ -1,6 +1,6 @@
 """
 MicroPython TinyRTC I2C Module, DS1307 RTC + AT24C32N EEPROM
-https://github.com/mcauser/micropython-tinyrtc
+https://github.com/mcauser/micropython-tinyrtc-i2c
 
 MIT License
 Copyright (c) 2018 Mike Causer

--- a/ds1307.py
+++ b/ds1307.py
@@ -1,6 +1,6 @@
 """
 MicroPython TinyRTC I2C Module, DS1307 RTC + AT24C32N EEPROM
-https://github.com/mcauser/micropython-tinyrtc
+https://github.com/mcauser/micropython-tinyrtc-i2c
 
 MIT License
 Copyright (c) 2018 Mike Causer


### PR DESCRIPTION
Invalid links to the repo are found in two of the libraries. I have corrected them to point to the correct URLs of the repo.